### PR TITLE
Include all deprecations in /deprecations

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -43,6 +43,10 @@ export class ChromeStatusAPI {
     return [...Array(lastVersion).keys()].reverse();
   }
 
+  public async getFeaturesByType(type: number): Promise<any> {
+    return this.fetchJson(`/features?q=feature_type=${type}`);
+  }
+
   public async getFeatures(): Promise<any> {
     return this.getFeaturesForVersion();
   }


### PR DESCRIPTION
The Chromestatus `features` endpoint only returns the top 100 latest feature, which caused a large number of deprecations to be missing from the response.

We introcude `getFeaturesByType()`, which allows retrieving only features from a particular type. In this case, deprecations. Since we now have less than 100 features all is fine.

In the future, it may be necessary to paginate over features, but ChromeStatus hasn't fully implemented that in their API. It would be possible to achieve this using dates, but might be worth waiting until proper pagination lands into ChromeStatus.

Since some features don't have a Chrome release, some code changes where needed to handle that case.