### PR TITLE
Update to /api/v0 endpoints and add static feature pages

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -6,6 +6,7 @@ import { Route } from "./src/types.ts";
 import { StripStream } from "./src/stream-utils.ts";
 import index from "./src/routes/index.ts";
 import deprecations from "./src/routes/deprecations.ts";
+import feature from "./src/routes/feature.ts";
 
 class StaticFileHandler {
   #basePath: string = "";
@@ -56,6 +57,12 @@ serve((req: Request) => {
       new URLPattern({ pathname: "/deprecations" }),
       (request) => {
         return deprecations(request);
+      },
+    ],
+    [
+      new URLPattern({ pathname: "/feature/:id" }),
+      (request, match) => {
+        return feature(request, match);
       },
     ],
     // Fall through.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -28,14 +28,16 @@ export class ChromeStatusAPI {
     return this.fetchJson(`/api/v0/channels${queryString}`);
   }
 
-  public async getFeaturesForVersion(version?: number): Promise<any> {
-    let queryString = "";
-    if (version != undefined) {
-      queryString = `?milestone=${version}`;
-    }
-    return ((await this.fetchJson(`/features_v2.json`)) as any[]).filter(
-      (feature) => feature.milestone?.toString() == version?.toString()
+  // Returns features for a milestone grouped by status, e.g.
+  // { "Enabled by default": [...], "Origin trial": [...], ... }.
+  // The old `/features_v2.json` no longer carries a usable `milestone`
+  // field, so we use the milestone query on the v0 API which groups
+  // features by type server-side.
+  public async getFeaturesForVersion(version: number): Promise<any> {
+    const data = await this.fetchJson(
+      `/api/v0/features?milestone=${version}`
     );
+    return (data as any).features_by_type || {};
   }
 
   public async getVersions(): Promise<any> {
@@ -46,11 +48,12 @@ export class ChromeStatusAPI {
   }
 
   public async getFeaturesByType(type: number): Promise<any> {
-    return this.fetchJson(`/features_v2.json?q=feature_type=${type}`);
+    return this.fetchJson(`/api/v0/features?q=feature_type=${type}`);
   }
 
-  public async getFeatures(): Promise<any> {
-    return this.getFeaturesForVersion();
+  // Fetches a single feature's full detail by id.
+  public async getFeature(id: string | number): Promise<any> {
+    return this.fetchJson(`/api/v0/features/${id}`);
   }
 
   private async fetchJson<T>(path: string): Promise<T> {

--- a/src/routes/feature.ts
+++ b/src/routes/feature.ts
@@ -1,0 +1,172 @@
+import template from "../flora.ts";
+import { ChromeStatusAPI } from "../lib/utils.ts";
+import { escapeHtml } from "https://deno.land/x/escape_html/mod.ts";
+
+import nav from "../ui-components/nav.ts";
+
+// Renders a single browser's standards position / view, if present.
+const renderView = (label, browser) => {
+  const view = browser?.view;
+  if (!view || (!view.text && !view.url)) {
+    return template``;
+  }
+  const text = escapeHtml(view.text || "No signal");
+  return template`<li>${label}: ${
+    view.url
+      ? template`<a href=${view.url}>${text}</a>`
+      : template`${text}`
+  }${view.notes ? template` — ${escapeHtml(view.notes)}` : template``}</li>`;
+};
+
+// Renders a list of links (docs, samples, explainers).
+const renderLinks = (label, links) => {
+  if (!links || links.length == 0) {
+    return template``;
+  }
+  return template`<p>${label}: ${links.map(
+    (link) => template`<a href=${link}>${link}</a> `
+  )}</p>`;
+};
+
+const renderFeature = (feature) => {
+  const chrome = feature.browsers?.chrome || {};
+  const status = chrome.status || {};
+  const spec = feature.spec_link || feature.standards?.spec;
+  const bug = feature.bug_url || chrome.bug;
+
+  return template`
+  <p><a href="/">&larr; Back to release summary</a></p>
+  <h1>${escapeHtml(feature.name)}</h1>
+
+  <dl>
+    ${
+      feature.category
+        ? template`<dt>Category</dt><dd>${escapeHtml(feature.category)}</dd>`
+        : template``
+    }
+    ${
+      feature.feature_type
+        ? template`<dt>Type</dt><dd>${escapeHtml(feature.feature_type)}</dd>`
+        : template``
+    }
+    ${
+      status.text
+        ? template`<dt>Status</dt><dd>${escapeHtml(status.text)}${
+            status.milestone_str
+              ? template` (Chrome <a href="/?version=${escapeHtml(
+                  status.milestone_str
+                )}">${escapeHtml(status.milestone_str)}</a>)`
+              : template``
+          }</dd>`
+        : template``
+    }
+    ${
+      feature.intent_stage
+        ? template`<dt>Intent stage</dt><dd>${escapeHtml(
+            feature.intent_stage
+          )}</dd>`
+        : template``
+    }
+  </dl>
+
+  <h2>Summary</h2>
+  <p>${escapeHtml(feature.summary)}</p>
+
+  ${
+    feature.motivation
+      ? template`<h2>Motivation</h2><blockquote>${escapeHtml(
+          feature.motivation
+        )}</blockquote>`
+      : template``
+  }
+
+  <h2>Standards &amp; signals</h2>
+  <ul>
+    ${
+      spec
+        ? template`<li>Specification: <a href=${spec}>${spec}</a></li>`
+        : template``
+    }
+    ${renderView("Firefox", feature.browsers?.ff)}
+    ${renderView("Safari", feature.browsers?.safari)}
+    ${renderView("Web developers", feature.browsers?.webdev)}
+    ${
+      bug ? template`<li>Tracking bug: <a href=${bug}>${bug}</a></li>` : template``
+    }
+  </ul>
+
+  ${renderLinks("Docs", feature.doc_links || feature.resources?.docs)}
+  ${renderLinks("Samples", feature.sample_links || feature.resources?.samples)}
+  ${renderLinks("Explainers", feature.explainer_links)}
+
+  <p><a href="https://chromestatus.com/feature/${feature.id}">View on chromestatus.com</a></p>
+  `;
+};
+
+export default async function render(request: Request, match): Response {
+  const id = match?.pathname?.groups?.id;
+
+  if (!id || /\D/.test(id)) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const chromeStatusAPI = ChromeStatusAPI.getInstance();
+
+  let feature;
+  try {
+    feature = await chromeStatusAPI.getFeature(id);
+  } catch (_) {
+    feature = null;
+  }
+
+  if (!feature || !feature.id) {
+    return template`
+  <!doctype html>
+<html>
+
+<head>
+  <title>Feature not found</title>
+  <link rel="stylesheet" href="/styles/index.css">
+</head>
+
+<body>
+  ${nav()}
+  <h1>Feature not found</h1>
+  <p>No Chrome Platform Status feature with id <code>${escapeHtml(
+    id
+  )}</code> could be found.</p>
+</body>
+
+</html>`.then(
+      (data) =>
+        new Response(data, {
+          status: 404,
+          headers: { "content-type": "text/html" },
+        })
+    );
+  }
+
+  return template`
+  <!doctype html>
+<html>
+
+<head>
+  <title>${escapeHtml(feature.name)} — Chrome Platform Status</title>
+  <link rel="stylesheet" href="/styles/index.css">
+</head>
+
+<body>
+  ${nav()}
+  <div id="output">
+  ${renderFeature(feature)}
+  </div>
+</body>
+
+</html>`.then(
+    (data) =>
+      new Response(data, {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      })
+  );
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,23 +6,15 @@ import { escapeHtml } from "https://deno.land/x/escape_html/mod.ts";
 import nav from "../ui-components/nav.ts";
 import { join } from "https://deno.land/std@0.152.0/path/mod.ts";
 
-const renderData = async (version, versionData) => {
-  const enabled =
-    versionData.filter((feature) => {
-      return feature.browsers.chrome.status.text == "Enabled by default";
-    }) || [];
-  const originTrials =
-    versionData.filter((feature) => feature.browsers.chrome.origintrial) || [];
+const renderData = async (version, featuresByType) => {
+  // The v0 API groups features by status text. Pull each bucket out,
+  // defaulting to an empty list when a milestone has none of that type.
+  const enabled = featuresByType["Enabled by default"] || [];
+  const originTrials = featuresByType["Origin trial"] || [];
   const flaggedFeatures =
-    versionData.filter((feature) => feature.browsers.chrome.flag) || [];
-  const removed =
-    versionData.filter(
-      (feature) => feature.browsers.chrome.status.text == "Removed"
-    ) || [];
-  const deprecated =
-    versionData.filter(
-      (feature) => feature.browsers.chrome.status.text == "Deprecated"
-    ) || [];
+    featuresByType["In developer trial (Behind a flag)"] || [];
+  const removed = featuresByType["Removed"] || [];
+  const deprecated = featuresByType["Deprecated"] || [];
 
   console.log(
     enabled.length,
@@ -98,15 +90,18 @@ const renderResources = (resources) => {
       }</p>`;
 };
 
-const renderEnabled = (enabled, version) => template`
-    <h2 id="enabled">Enabled by default in ${version}</h2>
-    <p>This release of Chrome had ${enabled.length} new features.</p>
-    ${enabled.map(
-      (item) =>
-        template`<h3>${item.name}</h3>
-      <p>${escapeHtml(item.summary)} <a href=${
-          item.browsers.chrome.bug
-        }>#</a></p>
+// Renders a single feature block. `tag` is the heading level to use so
+// that enabled/origin-trial/flagged sections sit at h3 and the nested
+// deprecated/removed sections sit at h4.
+const renderFeature = (item, tag = "h3") => {
+  const bug = item.browsers?.chrome?.bug;
+  const spec = item.standards?.spec;
+  return template`<${tag}><a href="/feature/${item.id}">${escapeHtml(
+    item.name
+  )}</a></${tag}>
+      <p>${escapeHtml(item.summary)}${
+    bug ? template` <a href=${bug}>#</a>` : template``
+  }</p>
       ${
         "motivation" in item
           ? template`<p>${
@@ -116,109 +111,40 @@ const renderEnabled = (enabled, version) => template`
             )}</blockquote></p>`
           : template``
       }
-      <p>This feature was specified <a href=${
-        item.standards.spec
-      }>in this Spec</a>.</p>
-      ${renderResources(item.resources)}`
-    )}`;
+      ${
+        spec
+          ? template`<p>This feature was specified <a href=${spec}>in this Spec</a>.</p>`
+          : template``
+      }
+      ${renderResources(item.resources)}`;
+};
+
+const renderEnabled = (enabled, version) => template`
+    <h2 id="enabled">Enabled by default in ${version}</h2>
+    <p>This release of Chrome had ${enabled.length} new features.</p>
+    ${enabled.map((item) => renderFeature(item, "h3"))}`;
 
 const renderOriginTrials = (ot, version) => template`
     <h2 id="origin-trial">Origin Trials in-progress in ${version}</h2>
     <p>This release of Chrome had ${ot.length} new origin trials.</p>
-    ${ot.map(
-      (item) =>
-        template`<h3>${item.name}</h3>
-      <p>${escapeHtml(item.summary)} <a href=${
-          item.browsers.chrome.bug
-        }>#</a></p>
-      ${
-        "motivation" in item
-          ? template`<p>${
-              item.creator
-            } created this feature because: <blockquote>${escapeHtml(
-              item.motivation
-            )}</blockquote></p>`
-          : template``
-      }
-      <p>This feature was specified <a href=${
-        item.standards.spec
-      }>in this Spec</a>.</p>
-      ${renderResources(item.resources)}`
-    )}`;
+    ${ot.map((item) => renderFeature(item, "h3"))}`;
 
 const renderFlaggedFeatures = (flagged, version) => template`
     <h2 id="flagged">Flagged features in ${version}</h2>
     <p>This release of Chrome had ${
       flagged.length
     } are available behind a flag.</p>
-    ${flagged.map(
-      (item) =>
-        template`<h3>${item.name}</h3>
-      <p>${escapeHtml(item.summary)} <a href=${
-          item.browsers.chrome.bug
-        }>#</a></p>
-      ${
-        "motivation" in item
-          ? template`<p>${
-              item.creator
-            } created this feature because: <blockquote>${escapeHtml(
-              item.motivation
-            )}</blockquote></p>`
-          : template``
-      }
-      <p>This feature was specified <a href=${
-        item.standards.spec
-      }>in this Spec</a>.</p>
-      ${renderResources(item.resources)}`
-    )}`;
+    ${flagged.map((item) => renderFeature(item, "h3"))}`;
 
 const renderDeprecatedFeatures = (deprecated, version) => template`
     <h3 id="deprecated">Deprecated features in ${version}</h3>
     <p>This release of Chrome had ${deprecated.length} features deprecated.</p>
-    ${deprecated.map(
-      (item) =>
-        template`<h4>${item.name}</h4>
-      <p>${escapeHtml(item.summary)} <a href=${
-          item.browsers.chrome.bug
-        }>#</a></p>
-      ${
-        "motivation" in item
-          ? template`<p>${
-              item.creator
-            } created this feature because: <blockquote>${escapeHtml(
-              item.motivation
-            )}</blockquote></p>`
-          : template``
-      }
-      <p>This feature was specified <a href=${
-        item.standards.spec
-      }>in this Spec</a>.</p>
-      ${renderResources(item.resources)}`
-    )}`;
+    ${deprecated.map((item) => renderFeature(item, "h4"))}`;
 
 const renderRemovedFeatures = (removed, version) => template`
     <h3 id="removed">Removed features in ${version}</h3>
     <p>This release of Chrome had ${removed.length} features removed.</p>
-    ${removed.map(
-      (item) =>
-        template`<h4>${item.name}</h4>
-      <p>${escapeHtml(item.summary)} <a href=${
-          item.browsers.chrome.bug
-        }>#</a></p>
-      ${
-        "motivation" in item
-          ? template`<p>${
-              item.creator
-            } created this feature because: <blockquote>${escapeHtml(
-              item.motivation
-            )}</blockquote></p>`
-          : template``
-      }
-      <p>This feature was specified <a href=${
-        item.standards.spec
-      }>in this Spec</a>.</p>
-      ${renderResources(item.resources)}`
-    )}`;
+    ${removed.map((item) => renderFeature(item, "h4"))}`;
 
 export default async function render(request: Request): Response {
   const url = new URL(request.url);


### PR DESCRIPTION
chromestatus.com's JSON API changed shape: features_v2.json no longer carries a usable `milestone` field (now null) or browsers.chrome.desktop, so the old "fetch everything and filter by milestone" approach returned no features and the release summary rendered empty.

Move all data access onto the current /api/v0 endpoints:

- getFeaturesForVersion now uses /api/v0/features?milestone=<v> and returns the server-side features_by_type grouping.
- getFeaturesByType now uses /api/v0/features?q=feature_type=<t> (the old features_v2.json?q= ignored the query and returned everything, which had also silently broken the deprecations page).
- Add getFeature(id) -> /api/v0/features/<id>.

index.ts reads the grouped buckets directly instead of filtering a flat array by status text, and the five near-identical feature renderers are collapsed into one renderFeature helper that links each feature to its own page and guards now-frequently-null bug/spec links.

Add a statically rendered page at /feature/<id> (e.g. /feature/5068127364186112) showing the feature's status, summary, motivation, spec, cross-browser signals, tracking bug and resources, with 404s for unknown or non-numeric ids.